### PR TITLE
Add embed buttons and settings

### DIFF
--- a/config/install/embed.settings.yml
+++ b/config/install/embed.settings.yml
@@ -1,0 +1,2 @@
+file_scheme: 'public'
+upload_directory: 'embed_buttons'

--- a/config/schema/embed.schema.yml
+++ b/config/schema/embed.schema.yml
@@ -1,0 +1,35 @@
+# Schema for the configuration files of the Embed module.
+
+embed.settings:
+  type: config_object
+  label: 'Embed settings'
+  mapping:
+    file_scheme:
+      type: string
+      label: 'File scheme for button images'
+    upload_directory:
+      type: string
+      label: 'Upload directory for button images'
+
+embed.button.*:
+  type: config_entity
+  label: 'Embed button'
+  mapping:
+    label:
+      type: label
+      label: 'Name'
+    id:
+      type: string
+      label: 'Machine name'
+    embed_type:
+      type: string
+      label: 'Embed type'
+    icon_uuid:
+      type: string
+      label: 'Button image'
+    display_plugins:
+      type: sequence
+      label: 'Allowed display plugins'
+      sequence:
+        type: string
+        label: 'Display plugin'

--- a/embed.libraries.yml
+++ b/embed.libraries.yml
@@ -1,0 +1,6 @@
+embed:
+  js:
+    js/embed.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal.ajax

--- a/embed.links.action.yml
+++ b/embed.links.action.yml
@@ -1,0 +1,5 @@
+embed.button_add:
+  route_name: embed.button_add
+  title: 'Add embed button'
+  appears_on:
+    - entity.embed_button.collection

--- a/embed.links.menu.yml
+++ b/embed.links.menu.yml
@@ -1,0 +1,5 @@
+entity.embed_button.collection:
+  title: 'Embed buttons'
+  parent: system.admin_config_content
+  description: 'Manage embed buttons.'
+  route_name: entity.embed_button.collection

--- a/embed.links.task.yml
+++ b/embed.links.task.yml
@@ -1,0 +1,9 @@
+entity.embed_button.collection:
+  title: List
+  route_name: entity.embed_button.collection
+  base_route: entity.embed_button.collection
+embed.settings:
+  title: Settings
+  route_name: embed.settings
+  base_route: entity.embed_button.collection
+  weight: 50

--- a/embed.permissions.yml
+++ b/embed.permissions.yml
@@ -1,0 +1,2 @@
+administer embed buttons:
+  title: 'Administer embed buttons'

--- a/embed.routing.yml
+++ b/embed.routing.yml
@@ -4,3 +4,43 @@ embed.preview:
     _controller: '\Drupal\embed\Controller\EmbedController::preview'
   requirements:
     _entity_access: 'filter_format.use'
+
+embed.settings:
+  path: '/admin/config/content/embed/settings'
+  defaults:
+    _form: '\Drupal\embed\Form\EmbedSettingsForm'
+    _title: 'Settings'
+  requirements:
+    _permission: 'administer embed buttons'
+
+entity.embed_button.collection:
+  path: '/admin/config/content/embed'
+  defaults:
+    _controller: '\Drupal\Core\Entity\Controller\EntityListController::listing'
+    entity_type: 'embed_button'
+    _title: 'Embed buttons'
+  requirements:
+    _permission: 'administer embed buttons'
+
+embed.button_add:
+  path: '/admin/config/content/embed/add'
+  defaults:
+    _entity_form: 'embed_button.add'
+    _title: 'Add embed button'
+  requirements:
+    _permission: 'administer embed butotns'
+
+entity.embed_button.edit_form:
+  path: '/admin/config/content/embed/manage/{embed_button}'
+  defaults:
+    _entity_form: 'embed_button.edit'
+  requirements:
+    _permission: 'administer embed buttons'
+
+entity.embed_button.delete_form:
+  path: '/admin/config/content/embed/manage/{embed_button}/delete'
+  defaults:
+    _entity_form: 'embed_button.delete'
+    _title: 'Delete'
+  requirements:
+    _entity_access: 'embed_button.delete'

--- a/js/embed.js
+++ b/js/embed.js
@@ -1,0 +1,61 @@
+/**
+ * @file
+ * Drupal Entity plugin.
+ */
+
+(function ($, Drupal) {
+
+  "use strict";
+
+  /**
+   * Attaches or detaches behaviors, except the ones we do not want.
+   *
+   * @param {string} action
+   *   Either 'attach' or 'detach'.
+   * @param context
+   *   The context argument for Drupal.attachBehaviors()/detachBehaviors().
+   * @param settings
+   *   The settings argument for Drupal.attachBehaviors()/detachBehaviors().
+   */
+  function runEmbedBehaviors(action, context, settings) {
+    // Do not run the excluded behaviors.
+    var stashed = {};
+    $.each(Drupal.embed.excludedBehaviors, function (i, behavior) {
+        stashed[behavior] = Drupal.behaviors[behavior];
+        delete Drupal.behaviors[behavior];
+    });
+    // Run the remaining behaviors.
+    (action == 'attach' ? Drupal.attachBehaviors : Drupal.detachBehaviors)(context, settings);
+    // Put the stashed behaviors back in.
+    $.extend(Drupal.behaviors, stashed);
+  }
+
+  /**
+   * Ajax 'embed_insert' command: insert the rendered embedded item.
+   *
+   * The regular Drupal.ajax.commands.insert() command cannot target elements
+   * within iframes. This is a skimmed down equivalent that works whether the
+   * CKEditor is in iframe or div area mode.
+   */
+  Drupal.AjaxCommands.prototype.embed_insert = function(ajax, response, status) {
+    var $target = ajax.element;
+    // No need to detach behaviors here, the widget is created fresh each time.
+    $target.html(response.data);
+    runEmbedBehaviors('attach', $target.get(0), response.settings || ajax.settings);
+  };
+
+  /**
+   * Stores settings specific to Embed module.
+   */
+  Drupal.embed = {
+    /**
+     * A list of behaviors which are to be excluded while attaching/detaching.
+     *
+     * - Drupal.behaviors.editor, to avoid editor inception.
+     * - Drupal.behaviors.contextual, to keep contextual links hidden.
+     */
+    excludedBehaviors: ['editor', 'contextual']
+  };
+
+
+})(jQuery, Drupal);

--- a/src/Ajax/EmbedInsertCommand.php
+++ b/src/Ajax/EmbedInsertCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\Ajax\EmbedInsertCommand.
+ */
+
+namespace Drupal\embed\Ajax;
+
+use Drupal\Core\Ajax\CommandInterface;
+use Drupal\Core\Ajax\CommandWithAttachedAssetsTrait;
+use Drupal\Core\Ajax\CommandWithAttachedAssetsInterface;
+
+/**
+ * AJAX command for inserting an embedded item in an editor.
+ *
+ * @ingroup ajax
+ */
+class EmbedInsertCommand implements CommandInterface, CommandWithAttachedAssetsInterface {
+
+  use CommandWithAttachedAssetsTrait;
+
+  /**
+   * The content for the matched element(s).
+   *
+   * Either a render array or an HTML string.
+   *
+   * @var string|array
+   */
+  protected $content;
+
+  /**
+   * Constructs an EmbedInsertCommand object.
+   *
+   * @param string|array $content
+   *   The content that will be inserted in the matched element(s), either a
+   *   render array or an HTML string.
+   */
+  public function __construct($content) {
+    $this->content = $content;
+  }
+
+  /**
+   * Implements Drupal\Core\Ajax\CommandInterface:render().
+   */
+  public function render() {
+    return array(
+      'command' => 'embed_insert',
+      'data' => $this->getRenderedContent(),
+    );
+  }
+
+}

--- a/src/Controller/EmbedController.php
+++ b/src/Controller/EmbedController.php
@@ -30,10 +30,10 @@ class EmbedController extends ControllerBase {
    *   The filter format.
    *
    * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-   *   Throws an exception if 'text' parameter is not found in the request.
+   *   Throws an exception if 'value' parameter is not found in the request.
    *
    * @return \Symfony\Component\HttpFoundation\Response
-   *   The preview of the entity specified by the data attributes.
+   *   The preview of the embedded item specified by the data attributes.
    */
   public function preview(Request $request, FilterFormatInterface $filter_format) {
     $text = $request->get('value');
@@ -41,10 +41,10 @@ class EmbedController extends ControllerBase {
       throw new NotFoundHttpException();
     }
 
-    $entity_output = (string) check_markup($text, $filter_format->id());
+    $output = (string) check_markup($text, $filter_format->id());
 
     $response = new AjaxResponse();
-    $response->addCommand(new ReplaceCommand(NULL, $entity_output));
+    $response->addCommand(new ReplaceCommand(NULL, $output));
     return $response;
   }
 

--- a/src/Controller/EmbedController.php
+++ b/src/Controller/EmbedController.php
@@ -8,8 +8,8 @@
 namespace Drupal\embed\Controller;
 
 use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\embed\Ajax\EmbedInsertCommand;
 use Drupal\filter\FilterFormatInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -41,10 +41,9 @@ class EmbedController extends ControllerBase {
       throw new NotFoundHttpException();
     }
 
-    $output = (string) check_markup($text, $filter_format->id());
-
+    $output = check_markup($text, $filter_format->id());
     $response = new AjaxResponse();
-    $response->addCommand(new ReplaceCommand(NULL, $output));
+    $response->addCommand(new EmbedInsertCommand($output));
     return $response;
   }
 

--- a/src/EmbedButtonInterface.php
+++ b/src/EmbedButtonInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\EmbedButtonInterface.
+ */
+
+namespace Drupal\embed;
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+
+/**
+ * Provides an interface defining a embed button entity.
+ */
+interface EmbedButtonInterface extends ConfigEntityInterface {
+
+  /**
+   * Returns the embed type for which this button is enabled.
+   *
+   * @return string
+   *   Machine name of the embed type.
+   */
+  public function getEmbedType();
+
+  /**
+   * Returns the label of the embed type for which this button is enabled.
+   *
+   * @return string
+   *   Human readable label of the embed type.
+   */
+  public function getEmbedTypeLabel();
+
+  /**
+   * Returns the button's icon file.
+   *
+   * @return \Drupal\file\FileInterface
+   *   The file entity of the button icon.
+   */
+  public function getIconFile();
+
+  /**
+   * Returns the URL of the button's icon.
+   *
+   * @return string
+   *   The URL of the button icon.
+   */
+  public function getIconUrl();
+
+  /**
+   * Returns the list of display plugins allowed for the embed type.
+   *
+   * @return array
+   *   List of allowed display plugins.
+   */
+  public function getAllowedDisplayPlugins();
+
+}

--- a/src/EmbedButtonListBuilder.php
+++ b/src/EmbedButtonListBuilder.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\embed;
 
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
 use Drupal\Core\Entity\EntityInterface;
 
@@ -33,8 +34,8 @@ class EmbedButtonListBuilder extends ConfigEntityListBuilder {
    */
   public function buildRow(EntityInterface $entity) {
     /** @var \Drupal\embed\EmbedButtonInterface $entity */
-    $row['label'] = $this->getLabel($entity);
-    $row['embed_type'] = $entity->getEmbedTypeLabel();
+    $row['label'] = SafeMarkup::checkPlain($entity->label());
+    $row['embed_type'] = SafeMarkup::checkPlain($entity->getEmbedTypeLabel());
     $row['icon'] = \Drupal::theme()->render('image', [
       'uri' => $entity->getIconUrl(),
       'alt' => $this->t('Button icon for the @label button', array('@label' => $this->getLabel($entity)))

--- a/src/EmbedButtonListBuilder.php
+++ b/src/EmbedButtonListBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\EmbedButtonListBuilder.
+ */
+
+namespace Drupal\embed;
+
+use Drupal\Core\Config\Entity\ConfigEntityListBuilder;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Provides a listing of EmbedButton.
+ */
+class EmbedButtonListBuilder extends ConfigEntityListBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildHeader() {
+    $header['label'] = $this->t('Embed button');
+    $header['embed_type'] = $this->t('Embed type');
+    $header['icon'] = [
+      'data' => $this->t('Icon'),
+      'class' => array(RESPONSIVE_PRIORITY_LOW),
+    ];
+    return $header + parent::buildHeader();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\embed\EmbedButtonInterface $entity */
+    $row['label'] = $this->getLabel($entity);
+    $row['embed_type'] = $entity->getEmbedTypeLabel();
+    $row['icon'] = \Drupal::theme()->render('image', [
+      'uri' => $entity->getIconUrl(),
+      'alt' => $this->t('Button icon for the @label button', array('@label' => $this->getLabel($entity)))
+    ]);
+    return $row + parent::buildRow($entity);
+  }
+
+}

--- a/src/EmbedType/EmbedTypeManager.php
+++ b/src/EmbedType/EmbedTypeManager.php
@@ -36,4 +36,16 @@ class EmbedTypeManager extends DefaultPluginManager {
     $this->setCacheBackend($cache_backend, 'embed_type_plugins');
   }
 
+  /**
+   * Provides a list of plugins suitable for form options.
+   *
+   * @return array
+   *   An array of valid plugin labels, keyed by plugin ID.
+   */
+  public function getDefinitionOptions() {
+    return array_map(function ($definition) {
+      return (string) $definition['label'];
+    }, $this->getDefinitions());
+  }
+
 }

--- a/src/Entity/EmbedButton.php
+++ b/src/Entity/EmbedButton.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\Entity\EmbedButton.
+ */
+
+namespace Drupal\embed\Entity;
+
+use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\embed\EmbedButtonInterface;
+
+/**
+ * Defines the EmbedButton entity.
+ *
+ * @ConfigEntityType(
+ *   id = "embed_button",
+ *   label = @Translation("Embed Button"),
+ *   handlers = {
+ *     "form" = {
+ *       "add" = "Drupal\embed\Form\EmbedButtonForm",
+ *       "edit" = "Drupal\embed\Form\EmbedButtonForm",
+ *       "delete" = "Drupal\Core\Entity\EntityDeleteForm"
+ *     },
+ *     "list_builder" = "Drupal\embed\EmbedButtonListBuilder",
+ *   },
+ *   admin_permission = "administer embed buttons",
+ *   config_prefix = "button",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "label",
+ *   },
+ *   links = {
+ *     "edit-form" = "/admin/config/content/embed/manage/{embed_button}",
+ *     "delete-form" = "/admin/config/content/embed/manage/{embed_button}/delete",
+ *     "collection" = "/admin/config/content/embed",
+ *   },
+ *   config_export = {
+ *     "label",
+ *     "id",
+ *     "embed_type",
+ *     "icon_uuid",
+ *     "display_plugins",
+ *   }
+ * )
+ */
+class EmbedButton extends ConfigEntityBase implements EmbedButtonInterface {
+
+  /**
+   * The EmbedButton ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * Label of EmbedButton.
+   *
+   * @var string
+   */
+  public $label;
+
+  /**
+   * Selected embed type.
+   *
+   * @var string
+   */
+  public $embed_type;
+
+  /**
+   * UUID of the button's icon file.
+   *
+   * @var string
+   */
+  public $icon_uuid;
+
+  /**
+   * Array of allowed display plugins for the entity type.
+   *
+   * An empty array signifies that all are allowed.
+   *
+   * @var array
+   */
+  public $display_plugins;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEmbedType() {
+    return $this->embed_type;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEmbedTypeLabel() {
+    if ($definition = $this->embedTypeManager()->getDefinition($this->embed_type, FALSE)) {
+      return $definition['label'];
+    }
+    else {
+      return t('Unknown');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIconFile() {
+    if ($this->icon_uuid) {
+      return $this->entityManager()->loadEntityByUuid('file', $this->icon_uuid);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIconUrl() {
+    if ($image = $this->getIconFile()) {
+      return $image->url();
+    }
+    else {
+      return file_create_url(drupal_get_path('module', 'embed') . '/js/plugins/drupalembed/embed.png');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAllowedDisplayPlugins() {
+    $allowed_display_plugins = array();
+    // Include only those plugin ids in result whose value is set.
+    foreach ($this->display_plugins as $key => $value) {
+      if ($value) {
+        $allowed_display_plugins[$key] = $value;
+      }
+    }
+    return $allowed_display_plugins;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    parent::calculateDependencies();
+
+    // Add the file icon entity as dependency if an UUID was specified.
+    if ($this->icon_uuid && $file_icon = $this->entityManager()->loadEntityByUuid('file', $this->icon_uuid)) {
+      $this->addDependency($file_icon->getConfigDependencyKey(), $file_icon->getConfigDependencyName());
+    }
+
+    return $this->dependencies;
+  }
+
+}

--- a/src/Form/EmbedButtonForm.php
+++ b/src/Form/EmbedButtonForm.php
@@ -1,0 +1,347 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\Form\EmbedButtonForm.
+ */
+
+namespace Drupal\embed\Form;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\ckeditor\CKEditorPluginManager;
+use Drupal\embed\EmbedDisplay\EmbedDisplayManager;
+use Drupal\embed\EmbedType\EmbedTypeManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form controller for embed button forms.
+ */
+class EmbedButtonForm extends EntityForm {
+
+  /**
+   * The entity manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * The type plugin manager.
+   *
+   * @var \Drupal\embed\EmbedType\EmbedTypeManager
+   */
+  protected $typePluginManager;
+
+  /**
+   * The display plugin manager.
+   *
+   * @var \Drupal\embed\EmbedDisplay\EmbedDisplayManager
+   */
+  protected $displayPluginManager;
+
+  /**
+   * The CKEditor plugin manager.
+   *
+   * @var \Drupal\ckeditor\CKEditorPluginManager
+   */
+  protected $ckeditorPluginManager;
+
+  /**
+   * The embed settings config object.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $entityEmbedConfig;
+
+  /**
+   * Constructs a new EmbedButtonForm.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The entity manager service.
+   * @param \Drupal\embed\EmbedType\EmbedTypeManager $embed_type_manager
+   *   The embed type plugin manager.
+   * @param \Drupal\embed\EmbedDisplay\EmbedDisplayManager $display_plugin_manager
+   *   The embed display plugin manager.
+   * @param \Drupal\ckeditor\CKEditorPluginManager $ckeditor_plugin_manager
+   *   The CKEditor plugin manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(EntityManagerInterface $entity_manager, EmbedTypeManager $embed_type_manager, EmbedDisplayManager $display_plugin_manager, CKEditorPluginManager $ckeditor_plugin_manager, ConfigFactoryInterface $config_factory) {
+    $this->entityManager = $entity_manager;
+    $this->typePluginManager = $embed_type_manager;
+    $this->displayPluginManager = $display_plugin_manager;
+    $this->ckeditorPluginManager = $ckeditor_plugin_manager;
+    $this->entityEmbedConfig = $config_factory->get('embed.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.manager'),
+      $container->get('plugin.manager.embed.type'),
+      $container->get('plugin.manager.embed.display'),
+      $container->get('plugin.manager.ckeditor.plugin'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    /** @var \Drupal\embed\EmbedButtonInterface $embed_button */
+    $embed_button = $this->entity;
+
+    $form['label'] = array(
+      '#title' => t('Label'),
+      '#type' => 'textfield',
+      '#default_value' => $embed_button->label(),
+      '#description' => t('The human-readable name of this embed button. This text will be displayed as part of the list on the <em>Add content</em> page. This name must be unique.'),
+      '#required' => TRUE,
+      '#size' => 30,
+    );
+
+    $form['id'] = array(
+      '#type' => 'machine_name',
+      '#default_value' => $embed_button->id(),
+      '#maxlength' => EntityTypeInterface::BUNDLE_MAX_LENGTH,
+      '#disabled' => !$embed_button->isNew(),
+      '#machine_name' => array(
+        'exists' => ['Drupal\embed\Entity\EmbedButton', 'load'],
+        'source' => array('label'),
+      ),
+      '#description' => t('A unique machine-readable name for this embed button. It must only contain lowercase letters, numbers, and underscores.'),
+    );
+
+    $form['embed_type'] = array(
+      '#type' => 'select',
+      '#title' => $this->t('Embed type'),
+      '#options' => $this->typePluginManager->getDefinitionOptions(),
+      '#default_value' => $embed_button->getEmbedType(),
+      '#description' => $this->t("Embed type for which this button is to enabled."),
+      //'#required' => TRUE,
+      '#ajax' => array(
+        'callback' => '::updateEntityTypeDependentFields',
+        'effect' => 'fade',
+      ),
+      '#disabled' => !$embed_button->isNew(),
+    );
+
+    $file_scheme = $this->entityEmbedConfig->get('file_scheme');
+    $upload_directory = $this->entityEmbedConfig->get('upload_directory');
+    $upload_location = $file_scheme . '://' . $upload_directory . '/';
+
+    $form['icon_file'] = array(
+      '#title' => $this->t('Button icon image'),
+      '#type' => 'managed_file',
+      '#description' => $this->t("Image for the button to be shown in CKEditor toolbar. Leave empty to use the default Entity icon."),
+      '#upload_location' => $upload_location,
+      '#upload_validators' => array(
+        'file_validate_extensions' => array('gif png jpg jpeg'),
+        'file_validate_image_resolution' => array('32x32', '16x16'),
+      ),
+    );
+    if ($file = $embed_button->getIconFile()) {
+      $form['icon_file']['#default_value'] = array('target_id' => $file->id());
+    }
+
+    /*$form['display_plugins'] = array(
+      '#type' => 'checkboxes',
+      '#default_value' => $embed_button->display_plugins ?: array(),
+      '#prefix' => '<div id="display-plugins-wrapper">',
+      '#suffix' => '</div>',
+    );
+
+    $entity_type_id = $form_state->getValue('entity_type') ?: $embed_button->entity_type;
+    if ($entity_type_id) {
+      $entity_type = $this->entityManager->getDefinition($entity_type_id);
+      // If the entity has bundles, allow option to restrict to bundle(s).
+      if ($entity_type->hasKey('bundle')) {
+        foreach ($this->entityManager->getBundleInfo($entity_type_id) as $bundle_id => $bundle_info) {
+          $bundle_options[$bundle_id] = $bundle_info['label'];
+        }
+
+        // Hide selection if there's just one option, since that's going to be
+        // allowed in either case.
+        if (count($bundle_options) > 1) {
+          $form['entity_type_bundles'] += array(
+            '#title' => $entity_type->getBundleLabel() ?: $this->t('Bundles'),
+            '#options' => $bundle_options,
+            '#description' => $this->t('If none are selected, all are allowed.'),
+          );
+        }
+      }
+
+      // Allow option to limit display plugins.
+      $form['display_plugins'] += array(
+        '#title' => $this->t('Allowed display plugins'),
+        '#options' => $this->displayPluginManager->getDefinitionOptionsForEntityType($entity_type_id),
+        '#description' => $this->t('If none are selected, all are allowed. Note that these are the plugins which are allowed for this entity type, all of these might not be available for the selected entity.'),
+      );
+    }
+    // Set options to an empty array if it hasn't been set so far.
+    if (!isset($form['entity_type_bundles']['#options'])) {
+      $form['entity_type_bundles']['#options'] = array();
+    }
+    if (!isset($form['display_plugins']['#options'])) {
+      $form['display_plugins']['#options'] = array();
+    }*/
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    $embed_button = $this->entity;
+    if ($embed_button->isNew()) {
+      // Get a list of all buttons that are provided by all plugins.
+      $all_buttons = array_reduce($this->ckeditorPluginManager->getButtons(), function($result, $item) {
+        return array_merge($result, array_keys($item));
+      }, array());
+      // Ensure that button ID is unique.
+      if (in_array($embed_button->id(), $all_buttons)) {
+        $form_state->setErrorByName('id', $this->t('A CKEditor button with ID %id already exists.', array('%id' => $embed_button->id())));
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\embed\EmbedButtonInterface $embed_button */
+    $embed_button = $this->entity;
+
+    $icon_fid = $form_state->getValue(array('icon_file', '0'));
+    // If a file was uploaded to be used as the icon, get its UUID to be stored
+    // in the config entity.
+    if (!empty($icon_fid) && $file = $this->entityManager->getStorage('file')->load($icon_fid)) {
+      $embed_button->set('icon_uuid', $file->uuid());
+    }
+    else {
+      $embed_button->set('icon_uuid', NULL);
+    }
+
+    $status = $embed_button->save();
+
+    $t_args = array('%label' => $embed_button->label());
+
+    if ($status == SAVED_UPDATED) {
+      drupal_set_message(t('The embed button %label has been updated.', $t_args));
+    }
+    elseif ($status == SAVED_NEW) {
+      drupal_set_message(t('The embed button %label has been added.', $t_args));
+      $context = array_merge($t_args, array('link' => $embed_button->link($this->t('View'), 'collection')));
+      $this->logger('embed')->notice('Added embed button %label.', $context);
+    }
+
+    $form_state->setRedirectUrl($embed_button->urlInfo('collection'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  /*protected function copyFormValuesToEntity(\Drupal\embed\EmbedButtonInterface $entity, array $form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+
+    $icon_fid = $form_state->getValue(array('icon_file', '0'));
+    // If a file was uploaded to be used as the icon, get its UUID to be stored
+    // in the config entity.
+    if (!empty($icon_fid) && $file = $this->entityManager->getStorage('file')->load($icon_fid)) {
+      $icon_uuid = $file->uuid();
+    }
+    else {
+      $icon_uuid = NULL;
+    }
+
+    // Set all form values in the entity except the button icon since it is a
+    // managed file element in the form but we want its UUID instead, which
+    // will be separately set later.
+    foreach ($values as $key => $value) {
+      if ($key != 'icon_file') {
+        $entity->set($key, $value);
+      }
+    }
+
+    // Set the UUID of the button icon.
+    $entity->set('icon_uuid', $icon_uuid);
+  }*/
+
+  /**
+   * Builds a list of entity type labels suitable for embed button options.
+   *
+   * Configuration entity types without a view builder are filtered out while
+   * all other entity types are kept.
+   *
+   * @return array
+   *   An array of entity type labels, keyed by entity type name.
+   */
+  /*protected function getFilteredEntityTypes() {
+    $options = array();
+    $definitions = $this->entityManager->getDefinitions();
+
+    foreach ($definitions as $entity_type_id => $definition) {
+      // Don't include configuration entities which do not have a view builder.
+      if ($definition->getGroup() != 'configuration' || $definition->hasViewBuilderClass()) {
+        $options[$definition->getGroupLabel()][$entity_type_id] = $definition->getLabel();
+      }
+    }
+
+    // Group entity type labels.
+    foreach ($options as &$group_options) {
+      // Sort the list alphabetically by group label.
+      array_multisort($group_options, SORT_ASC, SORT_NATURAL);
+    }
+
+    // Make sure that the 'Content' group is situated at the top.
+    $content = $this->t('Content', array(), array('context' => 'Entity type group'));
+    $options = array($content => $options[$content]) + $options;
+
+    return $options;
+  }*/
+
+  /**
+   * Ajax callback to update the form fields which depend on entity type.
+   *
+   * @param array $form
+   *   The build form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return AjaxResponse
+   *   Ajax response with updated options for entity type bundles.
+   */
+  public function updateEntityTypeDependentFields(array &$form, FormStateInterface $form_state) {
+    $response = new AjaxResponse();
+
+    // Update options for entity type bundles.
+    $response->addCommand(new ReplaceCommand(
+      '#bundle-embed-type-wrapper',
+      $form['entity_type_bundles']
+    ));
+
+    // Update options for display plugins.
+    $response->addCommand(new ReplaceCommand(
+      '#display-plugins-wrapper',
+      $form['display_plugins']
+    ));
+
+    return $response;
+  }
+}

--- a/src/Form/EmbedButtonForm.php
+++ b/src/Form/EmbedButtonForm.php
@@ -120,7 +120,6 @@ class EmbedButtonForm extends EntityForm {
       '#disabled' => !$embed_button->isNew(),
       '#machine_name' => array(
         'exists' => ['Drupal\embed\Entity\EmbedButton', 'load'],
-        'source' => array('label'),
       ),
       '#description' => t('A unique machine-readable name for this embed button. It must only contain lowercase letters, numbers, and underscores.'),
     );
@@ -131,7 +130,7 @@ class EmbedButtonForm extends EntityForm {
       '#options' => $this->typePluginManager->getDefinitionOptions(),
       '#default_value' => $embed_button->getEmbedType(),
       '#description' => $this->t("Embed type for which this button is to enabled."),
-      //'#required' => TRUE,
+      '#required' => TRUE,
       '#ajax' => array(
         'callback' => '::updateEntityTypeDependentFields',
         'effect' => 'fade',

--- a/src/Form/EmbedSettingsForm.php
+++ b/src/Form/EmbedSettingsForm.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\Form\EmbedSettingsForm.
+ */
+namespace Drupal\embed\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+
+/**
+ * Configure update settings for this site.
+ */
+class EmbedSettingsForm extends ConfigFormBase {
+
+  /**
+   * The stream wrapper manager.
+   *
+   * @var \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface
+   */
+  protected $streamWrapperManager;
+
+  /**
+   * Constructs a EmbedSettingsForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
+   *   The stream wrapper manager.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, StreamWrapperManagerInterface $stream_wrapper_manager) {
+    parent::__construct($config_factory);
+    $this->streamWrapperManager = $stream_wrapper_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static (
+      $container->get('config.factory'),
+      $container->get('stream_wrapper_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'embed_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['embed.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('embed.settings');
+
+    $scheme_options = \Drupal::service('stream_wrapper_manager')->getNames(StreamWrapperInterface::WRITE_VISIBLE);
+    $form['file_scheme'] = array(
+      '#type' => 'radios',
+      '#title' => t('Upload destination'),
+      '#options' => $scheme_options,
+      '#default_value' => $config->get('file_scheme'),
+      '#description' => t('Select where the uploaded button icon files should be stored.'),
+    );
+
+    $form['upload_directory'] = array(
+      '#type' => 'textfield',
+      '#title' => t('File directory'),
+      '#default_value' => $config->get('upload_directory'),
+      '#description' => t('Optional subdirectory within the upload destination where files will be stored. Do not include preceding or trailing slashes.'),
+      '#element_validate' => array(array(get_class($this), 'validateDirectory')),
+    );
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Form API callback
+   *
+   * Removes slashes from the beginning and end of the destination value and
+   * ensures that the file directory path is not included at the beginning of the
+   * value.
+   *
+   * This function is assigned as an #element_validate callback in
+   * fieldSettingsForm().
+   */
+  public static function validateDirectory($element, FormStateInterface $form_state) {
+    // Strip slashes from the beginning and end of $element['file_directory'].
+    $value = trim($element['#value'], '\\/');
+    $form_state->setValueForElement($element, $value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('embed.settings');
+    $config->set('file_scheme', $form_state->getValue('file_scheme'));
+    $config->set('upload_directory', $form_state->getValue('upload_directory'));
+    $config->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/src/Tests/EmbedTestBase.php
+++ b/src/Tests/EmbedTestBase.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\Tests\TestBase.
+ */
+
+namespace Drupal\embed\Tests;
+
+use Drupal\editor\Entity\Editor;
+use Drupal\filter\Entity\FilterFormat;
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Base class for all embed tests.
+ */
+abstract class EmbedTestBase extends WebTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = ['embed', 'editor', 'ckeditor', 'quickedit'];
+
+  /**
+   * The test user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $webUser;
+
+  protected function setUp() {
+    parent::setUp();
+
+    // Create Filtered HTML text format and enable entity_embed filter.
+    $format = FilterFormat::create([
+      'format' => 'embed_format',
+      'name' => 'Embed format',
+      'filters' => [
+      ],
+    ]);
+    $format->save();
+
+    $editor_group = [
+      'name' => 'Embed',
+      'items' => [
+      ],
+    ];
+    $editor = Editor::create([
+      'format' => 'embed_format',
+      'editor' => 'ckeditor',
+      'settings' => [
+        'toolbar' => [
+          'rows' => [[$editor_group]],
+        ],
+      ],
+    ]);
+    $editor->save();
+
+    // Create a user with required permissions.
+    $this->webUser = $this->drupalCreateUser([
+      'administer embed buttons',
+      'use text format embed_format',
+    ]);
+
+    // Log in the user.
+    $this->drupallogin($this->webUser);
+  }
+
+}

--- a/src/Tests/PreviewTest.php
+++ b/src/Tests/PreviewTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed\Tests\PreviewTest.
+ */
+
+namespace Drupal\embed\Tests;
+
+/**
+ * Tests the preview controller and route.
+ *
+ * @group embed
+ */
+class PreviewTest extends EmbedTestBase {
+
+  /**
+   * Tests the route used for generating preview of embedding entities.
+   */
+  public function testPreviewRoute() {
+    // Test preview route.
+    $content = 'Testing preview route';
+    $this->drupalGet('embed/preview/embed_format', array('query' => array('value' => $content)));
+    $this->assertResponse(200);
+    $this->assertText($content);
+
+    // Test preview route with an empty request.
+    $this->drupalGet('embed/preview/embed_format');
+    $this->assertResponse(404);
+
+    // Test preview route with an invalid text format.
+    $this->drupalGet('embed/preview/invalid_format');
+    $this->assertResponse(404);
+
+    // Log out the user to test access to the filter itself is checked.
+    $this->drupalLogout();
+
+    $this->drupalGet('embed/preview/embed_format', array('query' => array('value' => $content)));
+    $this->assertResponse(403);
+  }
+
+}

--- a/tests/embed_test/config/schema/embed_test.schema.yml
+++ b/tests/embed_test/config/schema/embed_test.schema.yml
@@ -1,0 +1,29 @@
+# Schema for the configuration files of the Embed test module.
+
+embed.button.*.third_party.embed_test_a:
+  type: mapping
+  label: 'Schema for embed_test_a additions to an embed button entity'
+  mapping:
+    type:
+      type: string
+      label: 'Type'
+    subtypes:
+      type: sequence
+      label: 'Subtypes'
+      sequence:
+        type: string
+        label: 'Subtype'
+
+embed.button.*.third_party.embed_test_b:
+  type: mapping
+  label: 'Schema for embed_test_a additions to an embed button entity'
+  mapping:
+    type:
+      type: string
+      label: 'Type'
+    subtypes:
+      type: sequence
+      label: 'Subtypes'
+      sequence:
+        type: string
+        label: 'Subtype'

--- a/tests/embed_test/embed_test.info.yml
+++ b/tests/embed_test/embed_test.info.yml
@@ -1,0 +1,6 @@
+name: 'Embed test'
+type: module
+description: 'Support module for the Embed module tests.'
+core: 8.x
+dependencies:
+  - embed_test

--- a/tests/embed_test/embed_test.module
+++ b/tests/embed_test/embed_test.module
@@ -1,0 +1,60 @@
+<?php
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function embed_test_form_embed_button_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form_object = $form_state->getFormObject();
+
+  /** @var \Drupal\embed\EmbedButtonInterface $button */
+  $button = $form_state->getTemporaryValue('embed_button');
+
+  if ($button->getEmbedType() == 'embed_test_a') {
+    $form['third_party_settings']['embed_test_a']['type'] = array(
+      '#type' => 'select',
+      '#title' => t('Type'),
+      '#options' => array(
+        'animals' => t('Animals'),
+        'airplanes' => t('Airplanes'),
+      ),
+      '#default_value' => $button->getThirdPartySetting('embed_test_a', 'type'),
+      '#required' => TRUE,
+      '#ajax' => array(
+        'callback' => array(get_class($form_object), 'updateThirdPartySettings'),
+        'effect' => 'fade',
+      ),
+    );
+
+    switch ($form['third_party_settings']['embed_test_a']['type']['#default_value']) {
+      case 'animals':
+        $form['third_party_settings']['embed_test_a']['subtype'] = array(
+          '#type' => 'checkboxes',
+          '#title' => t('Subtypes'),
+          '#options' => array(
+            'amphibians' => t('Amphibians'),
+            'birds' => t('Birds'),
+            'fish' => t('Fish'),
+            'mammals' => t('Mammals'),
+            'reptiles' => t('Reptiles'),
+          ),
+          '#default_value' => $button->getThirdPartySetting('embed_test_a', 'subtype', array()),
+        );
+        break;
+    }
+  }
+
+  if ($button->getEmbedType() == 'embed_test_b') {
+    $form['third_party_settings']['embed_test_b']['type'] = array(
+      '#type' => 'select',
+      '#title' => t('Type'),
+      '#options' => array('ballads', 'buttons'),
+      '#default_value' => $button->getThirdPartySetting('embed_test_b', 'type'),
+      '#required' => TRUE,
+    );
+  }
+
+}

--- a/tests/embed_test/src/Plugin/EmbedType/EmbedTestA.php
+++ b/tests/embed_test/src/Plugin/EmbedType/EmbedTestA.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed_test\Plugin\EmbedType\EmbedTestA.
+ */
+
+namespace Drupal\embed_test\Plugin\EmbedType;
+
+use Drupal\Core\Plugin\PluginBase;
+
+/**
+ * Test embed type.
+ *
+ * @EmbedType(
+ *   id = "embed_test_a",
+ *   label = @Translation("Embed Test A")
+ * )
+ */
+class EmbedTestA {
+
+}

--- a/tests/embed_test/src/Plugin/EmbedType/EmbedTestB.php
+++ b/tests/embed_test/src/Plugin/EmbedType/EmbedTestB.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\embed_test\Plugin\EmbedType\EmbedTestB.
+ */
+
+namespace Drupal\embed_test\Plugin\EmbedType;
+
+use Drupal\Core\Plugin\PluginBase;
+
+/**
+ * Test embed type.
+ *
+ * @EmbedType(
+ *   id = "embed_test_b",
+ *   label = @Translation("Embed Test B")
+ * )
+ */
+class EmbedTestB {
+
+}


### PR DESCRIPTION
Remaining:
- [ ] Convert embed type to plugins that implement ConfigurablePluginInterface, PluginFormInterface, PluginInspectionInterface and then can alter in settings on the embed button form using buildConfigurationForm() which would be saved to third party settings on the config entity.
- [ ] Select allowed display plugins
