### PR TITLE
Use the file web-accesible URI of instead of the file url for the emb…

### DIFF
--- a/src/Entity/EmbedButton.php
+++ b/src/Entity/EmbedButton.php
@@ -131,7 +131,7 @@ class EmbedButton extends ConfigEntityBase implements EmbedButtonInterface {
    */
   public function getIconUrl() {
     if ($image = $this->getIconFile()) {
-      return $image->url();
+      return file_create_url($image->getFileUri());
     }
     else {
       return $this->getTypePlugin()->getDefaultIconUrl();


### PR DESCRIPTION
When using the file_entity and trying to update the icon of the embed button, the button will not be visible, because it will us a URL like file/fid which will return a web page instead of an image.

This patch will use the file_create_url() to generate the web-accessible URL of the file.
